### PR TITLE
fix(45): adding scan to secondary indexes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ jspm_packages
 
 .serverless
 .DS_Store
+/.idea

--- a/src/query/global_secondary_index.ts
+++ b/src/query/global_secondary_index.ts
@@ -67,6 +67,34 @@ export class FullGlobalSecondaryIndex<T extends Table, HashKeyType, RangeKeyType
       consumedCapacity: result.ConsumedCapacity,
     };
   }
+
+  public async scan(options: {
+    limit?: number,
+    totalSegments?: number,
+    segment?: number,
+    exclusiveStartKey?: DynamoDB.DocumentClient.Key,
+  }) {
+    const params: DynamoDB.DocumentClient.ScanInput = {
+      TableName: this.tableClass.metadata.name,
+      Limit: options.limit,
+      ExclusiveStartKey: options.exclusiveStartKey,
+      ReturnConsumedCapacity: "TOTAL",
+      TotalSegments: options.totalSegments,
+      Segment: options.segment,
+    };
+
+    const result = await this.tableClass.metadata.connection.documentClient.scan(params).promise();
+
+    return {
+      records: (result.Items || []).map((item) => {
+        return Codec.deserialize(this.tableClass, item);
+      }),
+      count: result.Count,
+      scannedCount: result.ScannedCount,
+      lastEvaluatedKey: result.LastEvaluatedKey,
+      consumedCapacity: result.ConsumedCapacity,
+    };
+  }
 }
 
 export class HashGlobalSecondaryIndex<T extends Table, HashKeyType> {

--- a/src/query/local_secondary_index.ts
+++ b/src/query/local_secondary_index.ts
@@ -67,4 +67,32 @@ export class LocalSecondaryIndex<T extends Table, HashKeyType, RangeKeyType> {
       consumedCapacity: result.ConsumedCapacity,
     };
   }
+
+  public async scan(options: {
+    limit?: number,
+    totalSegments?: number,
+    segment?: number,
+    exclusiveStartKey?: DynamoDB.DocumentClient.Key,
+  }) {
+    const params: DynamoDB.DocumentClient.ScanInput = {
+      TableName: this.tableClass.metadata.name,
+      Limit: options.limit,
+      ExclusiveStartKey: options.exclusiveStartKey,
+      ReturnConsumedCapacity: "TOTAL",
+      TotalSegments: options.totalSegments,
+      Segment: options.segment,
+    };
+
+    const result = await this.tableClass.metadata.connection.documentClient.scan(params).promise();
+
+    return {
+      records: (result.Items || []).map((item) => {
+        return Codec.deserialize(this.tableClass, item);
+      }),
+      count: result.Count,
+      scannedCount: result.ScannedCount,
+      lastEvaluatedKey: result.LastEvaluatedKey,
+      consumedCapacity: result.ConsumedCapacity,
+    };
+  }
 }


### PR DESCRIPTION
## BACKEND-STORY_ID One-sentence summary of changes
Adding Scan to GSI/LSI

#### Is it a breaking change?: NO / YES
no

### Why did you make these changes?
scan() is a valid function for dynamodb

Service `X` requires `Y` field from response entity of `Z` API call.

### What's changed in these changes?

I added `X` field to `Y` entity.

### What do you especially want to get reviewed?

The method of rendering `X` field

### Is there any other comments that every teammate should know?

You should use `X` field instead of using `Y` field


### Submission Type

* [ ] Bugfix
* [ X] New Feature
* [ ] Refactor

### All Submissions

* [X ] Have you added an explanation of what your changes?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you checked potential side effects that could make bad impacts to other services?


### New Features

* [ ] Have you configured CI/CD properly?
* [ ] Have you configured optimal memory size and timeouts of Lambda Function?
* [ ] Have you grant required permissions (e.g. IAM Policy, VPC Security Group)?
* [ ] Have you made required resources (e.g. DynamoDB Table, RDS Cluster)?
* [ ] Does it requires native addons dependency?
