### PR TITLE
feat: add region param

### DIFF
--- a/src/connections/dax_connection.ts
+++ b/src/connections/dax_connection.ts
@@ -10,14 +10,18 @@ export class DAXConnection implements Connection {
   private __client: AWS.DynamoDB; // tslint:disable-line
 
   constructor(options: {
-    endpoints: string[],
-    requestTimeout?: number,
+    region?: string | undefined;
+    endpoints: string[];
+    requestTimeout?: number;
   }) {
     this.__client = new AmazonDaxClient({
+      region: options.region,
       endpoints: options.endpoints,
       requestTimeout: options.requestTimeout,
     });
-    this.__documentClient = new DynamoDB.DocumentClient({ service: this.__client });
+    this.__documentClient = new DynamoDB.DocumentClient({
+      service: this.__client,
+    });
   }
 
   public get documentClient() {

--- a/src/connections/dax_connection.ts
+++ b/src/connections/dax_connection.ts
@@ -10,7 +10,7 @@ export class DAXConnection implements Connection {
   private __client: AWS.DynamoDB; // tslint:disable-line
 
   constructor(options: {
-    region?: string | undefined;
+    region?: string;
     endpoints: string[];
     requestTimeout?: number;
   }) {

--- a/src/connections/dynamodb_connection.ts
+++ b/src/connections/dynamodb_connection.ts
@@ -11,10 +11,12 @@ export class DynamoDBConnection implements Connection {
   private __client: AWS.DynamoDB; // tslint:disable-line
 
   constructor(options: {
-    endpoint: string | undefined,
-    enableAWSXray: boolean,
+    region?: string | undefined;
+    endpoint: string | undefined;
+    enableAWSXray: boolean;
   }) {
-    const dynamoDBOptions = {
+    const dynamoDBOptions: DynamoDB.ClientConfiguration = {
+      region: options.region,
       endpoint: options.endpoint,
       httpOptions: {
         agent: this.httpAgent(options.endpoint),

--- a/src/connections/dynamodb_connection.ts
+++ b/src/connections/dynamodb_connection.ts
@@ -11,7 +11,7 @@ export class DynamoDBConnection implements Connection {
   private __client: AWS.DynamoDB; // tslint:disable-line
 
   constructor(options: {
-    region?: string | undefined;
+    region?: string;
     endpoint: string | undefined;
     enableAWSXray: boolean;
   }) {


### PR DESCRIPTION
## BACKEND-STORY_ID One-sentence summary of changes

Adding a `region` option for `Windows Server` .

---

#### Is it a breaking change?: NO / YES

NO

---

### Why did you make these changes?

It seems that need to **explicitly** pass `REGION`, to use `DynamoDB` on `Windows`.
Even if the following method is performed, `Missing region in config` error still occurs.

Interestingly, the `AWSAccessKeyId` is successfully fetched from `shared credential`.

![3](https://user-images.githubusercontent.com/55947058/81027842-2ab83d00-8eba-11ea-9d9f-f6ba12288688.png)

- Setting AWS CLI Configure

![2](https://user-images.githubusercontent.com/55947058/81026468-2dfcfa00-8eb5-11ea-8b55-5f35a6867eb6.png)

- Setting Global Configure

```ts
AWS.config.update({
    region: "ap-northeast-2"
})
```

-  Setting Env Variables

![1](https://user-images.githubusercontent.com/55947058/81026289-926b8980-8eb4-11ea-90ac-580bf689a7af.png)





---

### What's changed in these changes?

Adding a `region` param to `option` of `dynamodb_connection`, `dax_connection`.

**dynamodb_connection.ts**
```ts
export class DynamoDBConnection implements Connection {
  constructor(options: {
    region?: string | undefined;       //< here
    endpoint: string | undefined;
    enableAWSXray: boolean;
  }) {
    const dynamoDBOptions: DynamoDB.ClientConfiguration = {
      region: options.region,          //< here
      endpoint: options.endpoint,
      httpOptions: {
        agent: this.httpAgent(options.endpoint),
      }
    };
    ..
  }
}
```

**dax_connection.ts**
```ts
export class DAXConnection implements Connection {
  constructor(options: {
    region?: string | undefined;    //< here
    endpoints: string[];
    requestTimeout?: number;
  }) {
    this.__client = new AmazonDaxClient({
      region: options.region,       //< here
      endpoints: options.endpoints,
      requestTimeout: options.requestTimeout,
    });
  }
}
```

The above modification seems to work well,
because it is based on the getting start of `amazon-dax-client` [below](https://www.npmjs.com/package/amazon-dax-client#usage-and-getting-started).

```ts
const AmazonDaxClient = require('amazon-dax-client');
 
// Replace this ...
var ddb = new AWS.DynamoDB({region: region});
/// with this ...
var dax = new AmazonDaxClient({endpoints: [endpoint], region: region});
 
// If using AWS.DynamoDB.DocumentClient ...
var doc = new AWS.DynamoDB.DocumentClient({service: dax});
```
---

### What do you especially want to get reviewed?

Create a connection via an explicitly given `region`.

---

### Is there any other comments that every teammate should know?

N/A

---

### Submission Type

* [x] Bugfix
* [x] New Feature
* [ ] Refactor

---

### All Submissions

* [ ] Have you added an explanation of what your changes?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you checked potential side effects that could make bad impacts to other services?

---

### New Features

* [ ] Have you configured CI/CD properly?
* [ ] Have you configured optimal memory size and timeouts of Lambda Function?
* [ ] Have you grant required permissions (e.g. IAM Policy, VPC Security Group)?
* [ ] Have you made required resources (e.g. DynamoDB Table, RDS Cluster)?
* [ ] Does it requires native addons dependency?
